### PR TITLE
build: Add -e flag for go list to fix build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ $(BIN_DIR):
 
 $(TOOLING): $(BIN_DIR)
 	@echo Installing tools from hack/tools.go
-	@cd hack && go list -mod=mod -tags tools -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %
+	@cd hack && go list -mod=mod -tags tools -e -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %


### PR DESCRIPTION
Think this will fix building, would like to add a mixin or two but my git diff is to large since main builds are failing.

```
Installing tools from hack/tools.go
tools.go:8:2: import "github.com/brancz/gojsontoyaml" is a program, not an importable package
```

https://github.com/golang/go/issues/61857#issuecomment-1670182050