### PR TITLE
Update cert-manager.json

### DIFF
--- a/assets/cert-manager/dashboards/cert-manager.json
+++ b/assets/cert-manager/dashboards/cert-manager.json
@@ -120,7 +120,7 @@
             {
                "expr": "sum by (condition) (certmanager_certificate_ready_status{ })",
                "interval": "",
-               "legendFormat": "{ {condition } }",
+               "legendFormat": "{{ condition }}",
                "refId": "A"
             }
          ],
@@ -423,7 +423,7 @@
             {
                "expr": "sum by (controller) (\n  rate(certmanager_controller_sync_call_count{ }[$__rate_interval ])\n)",
                "interval": "",
-               "legendFormat": "{ {controller } }",
+               "legendFormat": "{{controller }}",
                "refId": "A"
             }
          ],
@@ -524,7 +524,7 @@
             {
                "expr": "sum by (method, path, status) (\n  rate(certmanager_http_acme_client_request_count{ }[$__rate_interval ])\n)",
                "interval": "",
-               "legendFormat": "{ {method } } { {path } } { {status } }",
+               "legendFormat": "{{method }} {{path }} {{status }}",
                "refId": "A"
             }
          ],
@@ -625,7 +625,7 @@
             {
                "expr": "sum by (method, path, status) (rate(certmanager_http_acme_client_request_duration_seconds_sum{ }[$__rate_interval ]))\n/\nsum by (method, path, status) (rate(certmanager_http_acme_client_request_duration_seconds_count{ }[$__rate_interval ]))",
                "interval": "",
-               "legendFormat": "{ {method } } { {path } } { {status } }",
+               "legendFormat": "{{method }} {{path }} {{status }}",
                "refId": "A"
             }
          ],
@@ -746,7 +746,7 @@
                "hide": false,
                "interval": "",
                "intervalFactor": 2,
-               "legendFormat": "CPU { {pod } }",
+               "legendFormat": "CPU {{pod }}",
                "refId": "A"
             },
             {
@@ -755,7 +755,7 @@
                "hide": true,
                "interval": "",
                "intervalFactor": 1,
-               "legendFormat": "Limit { {pod } }",
+               "legendFormat": "Limit {{pod }}",
                "refId": "B"
             },
             {
@@ -764,7 +764,7 @@
                "hide": true,
                "interval": "",
                "intervalFactor": 1,
-               "legendFormat": "Request { {pod } }",
+               "legendFormat": "Request {{pod }}",
                "refId": "C"
             }
          ],
@@ -875,7 +875,7 @@
                "hide": false,
                "interval": "",
                "intervalFactor": 2,
-               "legendFormat": "{ {pod } }",
+               "legendFormat": "{{pod }}",
                "refId": "A"
             }
          ],
@@ -996,7 +996,7 @@
                "hide": false,
                "interval": "",
                "intervalFactor": 1,
-               "legendFormat": "Memory { {pod } }",
+               "legendFormat": "Memory {{pod }}",
                "refId": "A"
             },
             {
@@ -1004,7 +1004,7 @@
                "format": "time_series",
                "interval": "",
                "intervalFactor": 1,
-               "legendFormat": "Limit { {pod } }",
+               "legendFormat": "Limit {{pod }}",
                "refId": "B"
             },
             {
@@ -1012,7 +1012,7 @@
                "format": "time_series",
                "interval": "",
                "intervalFactor": 1,
-               "legendFormat": "Request { {pod } }",
+               "legendFormat": "Request {{pod }}",
                "refId": "C"
             }
          ],


### PR DESCRIPTION
Fix "template syntax" delimiters.

Current chart shows in the dashboards `{ { label } }` instead of `value` due to the incorrect syntax.